### PR TITLE
Fix #1 Add close method for Slack and SlackHttpClient

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/Slack.java
@@ -35,7 +35,7 @@ import java.net.URISyntaxException;
  * <p>
  * https://{your team name}.slack.com/apps/manage/custom-integrations
  */
-public class Slack {
+public class Slack implements AutoCloseable {
 
     private static final Slack SINGLETON = new Slack(SlackConfig.DEFAULT, new SlackHttpClient());
 
@@ -70,6 +70,11 @@ public class Slack {
 
     public SlackHttpClient getHttpClient() {
         return this.httpClient;
+    }
+
+    @Override
+    public void close() throws Exception {
+        getHttpClient().close();
     }
 
     /**

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/common/http/SlackHttpClient.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @Slf4j
-public class SlackHttpClient {
+public class SlackHttpClient implements AutoCloseable {
 
     private final OkHttpClient okHttpClient;
 
@@ -23,6 +23,15 @@ public class SlackHttpClient {
 
     public SlackHttpClient(OkHttpClient okHttpClient) {
         this.okHttpClient = okHttpClient;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.okHttpClient.dispatcher().executorService().shutdown();
+        this.okHttpClient.connectionPool().evictAll();
+        if (this.okHttpClient.cache() != null) {
+            this.okHttpClient.cache().close();
+        }
     }
 
     public SlackConfig getConfig() {

--- a/jslack-api-client/src/test/java/test_locally/api/util/SlackHttpClientTest.java
+++ b/jslack-api-client/src/test/java/test_locally/api/util/SlackHttpClientTest.java
@@ -1,0 +1,55 @@
+package test_locally.api.util;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.api.methods.MethodsClient;
+import com.github.seratch.jslack.api.methods.response.api.ApiTestResponse;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import okhttp3.FormBody;
+import okhttp3.Response;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class SlackHttpClientTest {
+
+    @Test
+    public void close_Slack() throws Exception {
+        {
+            Slack slack = Slack.getInstance();
+            MethodsClient methods = slack.methods();
+            ApiTestResponse response1 = methods.apiTest(r -> r.foo("bar"));
+            slack.close();
+            assertThat(response1.isOk(), is(true));
+
+            ApiTestResponse response2 = methods.apiTest(r -> r.foo("bar"));
+            slack.close();
+            assertThat(response2.isOk(), is(true));
+        }
+
+        try (Slack slack = Slack.getInstance()) {
+            MethodsClient methods = slack.methods();
+            ApiTestResponse response3 = methods.apiTest(r -> r.foo("bar"));
+            assertThat(response3.isOk(), is(true));
+        }
+    }
+
+    @Test
+    public void close_SlackHttpClient() throws Exception {
+        FormBody body = new FormBody.Builder().build();
+        {
+            SlackHttpClient httpClient = new SlackHttpClient();
+            for (int i = 0; i < 3; i++) {
+                Response response = httpClient.postForm("https://slack.com/api/api.test", body);
+                assertThat(response.code(), is(200));
+            }
+            httpClient.close();
+        }
+
+        try (SlackHttpClient httpClient = new SlackHttpClient()) {
+            Response response = httpClient.postForm("https://slack.com/api/api.test", body);
+            assertThat(response.code(), is(200));
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request fixes #1 by adding `close` method to `Slack` and `SlackHttpClient`.