### PR TITLE
Add http proxy support for all the clients

### DIFF
--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/SlackConfig.java
@@ -71,12 +71,22 @@ public class SlackConfig {
         public void setLegacyStatusEndpointUrlPrefix(String legacyStatusEndpointUrlPrefix) {
             throwException();
         }
+
+        @Override
+        public void setProxyUrl(String proxyUrl) {
+            throwException();
+        }
     };
 
     public SlackConfig() {
         getHttpClientResponseHandlers().add(new DetailedLoggingListener());
         getHttpClientResponseHandlers().add(new ResponsePrettyPrintingListener());
     }
+
+    /**
+     * The proxy server URL supposed to be used for all api calls.
+     */
+    private String proxyUrl = null;
 
     private boolean prettyResponseLoggingEnabled = false;
 

--- a/jslack-api-client/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
+++ b/jslack-api-client/src/main/java/com/github/seratch/jslack/api/rtm/RTMClient.java
@@ -6,6 +6,8 @@ import com.github.seratch.jslack.api.methods.request.rtm.RTMConnectRequest;
 import com.github.seratch.jslack.api.methods.response.rtm.RTMConnectResponse;
 import com.github.seratch.jslack.api.model.User;
 import lombok.extern.slf4j.Slf4j;
+import org.glassfish.tyrus.client.ClientManager;
+import org.glassfish.tyrus.client.ClientProperties;
 
 import javax.websocket.*;
 import java.io.Closeable;
@@ -77,8 +79,16 @@ public class RTMClient implements Closeable {
      * Calling this method won't work as you expect.
      */
     public void connect() throws IOException, DeploymentException {
-        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
-        container.connectToServer(this, wssUri);
+        ClientManager client = ClientManager.createClient();
+        String proxy = null;
+        proxy = slack.getHttpClient().getConfig().getProxyUrl();
+        if (proxy != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("The RTM client's going to use an HTTP proxy: {}", proxy);
+            }
+            client.getProperties().put(ClientProperties.PROXY_URI, proxy);
+        }
+        client.connectToServer(this, wssUri);
         log.debug("client connected to the server: {}", wssUri);
     }
 

--- a/jslack-api-client/src/test/java/config/Constants.java
+++ b/jslack-api-client/src/test/java/config/Constants.java
@@ -11,6 +11,9 @@ public class Constants {
 
     public static final String SLACK_SDK_TEST_USER_TOKEN = "SLACK_SDK_TEST_USER_TOKEN";
     public static final String SLACK_SDK_TEST_BOT_TOKEN = "SLACK_SDK_TEST_BOT_TOKEN";
+    // https://api.slack.com/apps?new_classic_app=1
+    public static final String SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN = "SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN";
+
     public static final String SLACK_SDK_TEST_SHARED_CHANNEL_ID = "SLACK_SDK_TEST_SHARED_CHANNEL_ID";
     public static final String SLACK_SDK_TEST_INCOMING_WEBHOOK_URL = "SLACK_SDK_TEST_INCOMING_WEBHOOK_URL";
     public static final String SLACK_SDK_TEST_INCOMING_WEBHOOK_CHANNEL_NAME = "SLACK_SDK_TEST_INCOMING_WEBHOOK_CHANNEL_NAME";

--- a/jslack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/ProxyTest.java
@@ -1,0 +1,93 @@
+package test_with_remote_apis;
+
+import com.github.seratch.jslack.Slack;
+import com.github.seratch.jslack.SlackConfig;
+import com.github.seratch.jslack.api.audit.response.SchemasResponse;
+import com.github.seratch.jslack.api.methods.response.auth.AuthTestResponse;
+import com.github.seratch.jslack.api.rtm.RTMClient;
+import com.github.seratch.jslack.api.scim.SCIMApiException;
+import com.github.seratch.jslack.api.scim.response.ServiceProviderConfigsGetResponse;
+import com.github.seratch.jslack.api.status.v2.model.CurrentStatus;
+import com.github.seratch.jslack.common.http.SlackHttpClient;
+import config.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Slf4j
+public class ProxyTest {
+
+    static String proxyUrl = "http://localhost:8888";
+
+    static SlackConfig config = new SlackConfig();
+
+    static {
+        config.setProxyUrl(proxyUrl);
+    }
+
+    static Slack slack = Slack.getInstance(config);
+
+    static String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    static String rtmBotToken = System.getenv(Constants.SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN);
+    static String scimToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+    static String auditLogsToken = System.getenv(Constants.SLACK_SDK_TEST_GRID_ORG_ADMIN_USER_TOKEN);
+
+    @Ignore
+    @Test
+    public void methods() throws Exception {
+        AuthTestResponse apiResponse = slack.methods().authTest(r -> r.token(botToken));
+        assertThat(apiResponse.getError(), is(nullValue()));
+    }
+
+    @Ignore
+    @Test
+    public void rtm() throws Exception {
+        SlackHttpClient httpClient = new SlackHttpClient();
+        Slack slack = Slack.getInstance(config, httpClient);
+        final AtomicBoolean received = new AtomicBoolean(false);
+        try (RTMClient rtm = slack.rtmConnect(rtmBotToken)) { // slack-msgs.com
+            rtm.addMessageHandler((msg) -> {
+                log.info("Got a message - {}", msg);
+                received.set(true);
+            });
+            rtm.addErrorHandler((e) -> {
+                log.error("Got an error - {}", e.getMessage(), e);
+            });
+            rtm.connect();
+            Thread.sleep(1000L);
+            rtm.sendMessage("foo");
+        }
+        assertThat(received.get(), is(true));
+    }
+
+    @Ignore
+    @Test
+    public void audit() throws Exception {
+        if (auditLogsToken != null) {
+            SchemasResponse response = slack.audit(auditLogsToken).getSchemas();
+            assertThat(response, is(notNullValue()));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void scim() throws IOException, SCIMApiException {
+        if (scimToken != null) {
+            ServiceProviderConfigsGetResponse response = slack.scim(scimToken).getServiceProviderConfigs(req -> req);
+            assertThat(response.getAuthenticationSchemes(), is(notNullValue()));
+        }
+    }
+
+    @Ignore
+    @Test
+    public void status() throws Exception {
+        CurrentStatus current = slack.status().current();
+        assertThat(current, is(notNullValue()));
+    }
+}

--- a/jslack-api-client/src/test/java/test_with_remote_apis/methods/rtm_Test.java
+++ b/jslack-api-client/src/test/java/test_with_remote_apis/methods/rtm_Test.java
@@ -47,16 +47,14 @@ public class rtm_Test {
         SlackTestConfig.awaitCompletion(testConfig);
     }
 
-    String botToken = System.getenv(Constants.SLACK_SDK_TEST_BOT_TOKEN);
+    String classicAppBotToken = System.getenv(Constants.SLACK_SDK_TEST_CLASSIC_APP_BOT_TOKEN);
     String channelCreationToken = System.getenv(Constants.SLACK_SDK_TEST_USER_TOKEN);
     User currentUser;
-
-    JsonParser jsonParser = new JsonParser();
 
     @Before
     public void loadBotUser() throws IOException {
         if (currentUser == null) {
-            RTMClient rtm = slack.rtmConnect(botToken);
+            RTMClient rtm = slack.rtmConnect(classicAppBotToken);
             currentUser = rtm.getConnectedBotUser();
         }
     }
@@ -150,7 +148,7 @@ public class rtm_Test {
 
             Thread.sleep(3000);
 
-            try (RTMClient rtm = slack.rtmStart(botToken)) {
+            try (RTMClient rtm = slack.rtmStart(classicAppBotToken)) {
                 User user = rtm.getConnectedBotUser();
 
                 assertThat(user.getId(), is(notNullValue()));
@@ -169,7 +167,7 @@ public class rtm_Test {
     @Ignore
     @Test
     public void rtmConnect_withoutFullConnectedUserInfo() throws Exception {
-        try (RTMClient rtm = slack.rtmConnect(botToken, false)) {
+        try (RTMClient rtm = slack.rtmConnect(classicAppBotToken, false)) {
             User user = rtm.getConnectedBotUser();
             assertThat(user.getId(), is(notNullValue()));
             assertThat(user.getName(), is(notNullValue()));
@@ -196,7 +194,7 @@ public class rtm_Test {
         RTMMessageHandler handler1 = new RTMMessageHandler() {
             @Override
             public void handle(String message) {
-                JsonObject json = jsonParser.parse(message).getAsJsonObject();
+                JsonObject json = JsonParser.parseString(message).getAsJsonObject();
                 if (json.get("error") == null) {
                     counter.incrementAndGet();
                 }


### PR DESCRIPTION
This pull request is a backport of https://github.com/slackapi/java-slack-sdk/pull/336

This change enables RTM clients to use an HTTP proxy endpoint for WS connections.